### PR TITLE
Fix for corrupted packet receiving without CRC fail

### DIFF
--- a/src/radio/LoRaReceiver.cpp
+++ b/src/radio/LoRaReceiver.cpp
@@ -47,7 +47,7 @@ void LoRaReceiver::initialize() {
                     Config::LoRa::IQ_INVERSION, Config::LoRa::TX_TIMEOUT_MS);
 
   LOG_INFO("Starting continuous reception with RX boost");
-  Radio.RxBoosted(0);  // Use boosted LNA gain for ~3dB better sensitivity
+  Radio.Rx(0);  // Use boosted LNA gain for ~3dB better sensitivity
 }
 
 void LoRaReceiver::processQueue() {
@@ -74,7 +74,7 @@ void LoRaReceiver::onRxDone(uint8_t *payload, uint16_t size, int16_t rssi,
   if (validationResult.isError()) {
     LOG_WARN_FMT("Invalid raw packet: %s", 
                  MeshCore::errorCodeToString(validationResult.error));
-    Radio.RxBoosted(0);
+    Radio.Rx(0);
     return;
   }
 
@@ -95,7 +95,7 @@ void LoRaReceiver::onRxDone(uint8_t *payload, uint16_t size, int16_t rssi,
     if (packetValidation.isError()) {
       LOG_WARN_FMT("Decoded packet validation failed: %s",
                    MeshCore::errorCodeToString(packetValidation.error));
-      Radio.RxBoosted(0);
+      Radio.Rx(0);
       return;
     }
 
@@ -108,17 +108,17 @@ void LoRaReceiver::onRxDone(uint8_t *payload, uint16_t size, int16_t rssi,
     LOG_WARN("Failed to decode packet");
   }
 
-  Radio.RxBoosted(0);
+  Radio.Rx(0);
 }
 
 void LoRaReceiver::onRxTimeout() {
   LOG_DEBUG("RX timeout, restarting reception");
-  Radio.RxBoosted(0);
+  Radio.Rx(0);
 }
 
 void LoRaReceiver::onRxError() {
   LOG_WARN("RX error occurred, restarting reception");
-  Radio.RxBoosted(0);
+  Radio.Rx(0);
 }
 
 void LoRaReceiver::resetPacketCount() {

--- a/src/radio/LoRaTransmitter.cpp
+++ b/src/radio/LoRaTransmitter.cpp
@@ -25,14 +25,14 @@ void LoRaTransmitter::onTxDone() {
   LoRaTransmitter &tx = getInstance();
   tx.notifyTxComplete(true);
   LOG_DEBUG("TX complete, returning to RX");
-  Radio.RxBoosted(0);  // Return to boosted RX mode
+  Radio.Rx(0);  // Return to boosted RX mode
 }
 
 void LoRaTransmitter::onTxTimeout() {
   LoRaTransmitter &tx = getInstance();
   tx.notifyTxComplete(false);
   LOG_WARN("TX timeout, returning to RX");
-  Radio.RxBoosted(0);  // Return to boosted RX mode
+  Radio.Rx(0);  // Return to boosted RX mode
 }
 
 bool LoRaTransmitter::transmit(const uint8_t *data, uint16_t length) {


### PR DESCRIPTION
This PR fixes corrupted packet reception without CRC failing. With Radio.RxBoosted(), some low signal packets will pass the CRC check, even when bits are flipped/corrupted. This fix will drop those corrupt packets and reduce unnecessary airtime by repeating corrupt data as new packets. As explained in #2 